### PR TITLE
Fixed incorrect returned by infector value. If Constructor returned object it shouldn't be 'this'

### DIFF
--- a/lib/infector.js
+++ b/lib/infector.js
@@ -135,7 +135,7 @@
    */
 
   Infector.prototype._beget = function(Constructor, dependencies){
-    function F() { Constructor.apply(this, dependencies); }
+    function F() { return Constructor.apply(this, dependencies); }
     F.prototype = Constructor.prototype;
     return new F();
   };

--- a/test/infector.test.js
+++ b/test/infector.test.js
@@ -91,4 +91,12 @@ describe('Infector', function(){
     expect(fooOne).not.to.equal(fooTwo);
   });
 
+  it('should return returned value from constructor', function () {
+    function Foo() { return { test: 'testvalue' }; }
+    infector.register({ foo: { type: Foo } });
+    var foo = infector.get('foo');
+    expect(foo).to.have.property('test');
+    expect(foo.test).to.be.equal('testvalue');
+  });
+
 });


### PR DESCRIPTION
Hi, it's nice product! But I found some glitch.
When Contructor returns object, then it's must be new `this` value.
Example: 

``` javascript
function Test() {
    return {
        doTest: 'test value'
    };
}
var test = new Test();
console.log(test);
//Should be: Object {doTest: "test value"} 
//Now: Object {}
```

But now it will be empty object, i.e. `this` of object.
